### PR TITLE
Cherry-pick of pybind11 cmake fixup (RobotLocomotion#7641)

### DIFF
--- a/tools/workspace/pybind11/pybind11-create-cps.py
+++ b/tools/workspace/pybind11/pybind11-create-cps.py
@@ -19,7 +19,10 @@ content = """
       "Compile-Features": ["c++11"]
     }
   },
-  "X-CMake-Includes": ["${CMAKE_CURRENT_LIST_DIR}/pybind11Tools.cmake"]
+  "X-CMake-Includes": ["${CMAKE_CURRENT_LIST_DIR}/pybind11Tools.cmake"],
+  "X-CMake-Variables-Init": {
+    "CMAKE_MODULE_PATH": "${CMAKE_CURRENT_LIST_DIR};${CMAKE_MODULE_PATH}"
+  }
 }
 """ % defs
 


### PR DESCRIPTION
init CMAKE_MODULE_PATH to be able to find pybind11 in CMake

This replaces https://github.com/osrf/drake/pull/2 and is required for merging the pybind migration PRs

Connects to ToyotaResearchInstitute/delphyne#169